### PR TITLE
Upgrade 5.10.x buildroot to 2022.02.3

### DIFF
--- a/Dockerfile.dapper
+++ b/Dockerfile.dapper
@@ -12,7 +12,7 @@ ENV SHELL /bin/bash
 ENV ARTIFACTS /usr/src
 WORKDIR ${DAPPER_SOURCE}
 
-ENV BUILDROOT_VERSION 2021.02.2
+ENV BUILDROOT_VERSION 2022.02.3
 ENV TARBALL ${BUILDROOT_VERSION}.tar.gz
 RUN cd ${ARTIFACTS} && \
     wget https://github.com/buildroot/buildroot/archive/$TARBALL

--- a/scripts/release
+++ b/scripts/release
@@ -12,6 +12,8 @@ echo "to publish release to github, run dist/publish.sh"
 echo "#!/bin/sh"> dist/publish.sh
 if [ "${ARCH}" == "amd64" ]; then
     echo "github-release release --user burmilla --repo os-initrd-base --tag "${RELEASE_VERSION}" --pre-release" >> dist/publish.sh
+    echo "echo Waiting 30 seconds after release creation to make sure that GitHub is ready for uploads" >> dist/publish.sh
+    echo "sleep 30s" >> dist/publish.sh
 fi
 echo "github-release upload  --user burmilla --repo os-initrd-base --tag "${RELEASE_VERSION}" --file ./dist/artifacts/os-initrd-base-${ARCH}.tar.gz --name os-initrd-base-${ARCH}.tar.gz" >> dist/publish.sh
 


### PR DESCRIPTION
Upgraded buildroot to 2022.02.3, cherry-picked other relevant commits from 4.14.x branch.