### PR TITLE
Update Buildroot 2022.02.3 config

### DIFF
--- a/config/amd64/buildroot-config-static
+++ b/config/amd64/buildroot-config-static
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Buildroot -g8e9d611-dirty Configuration
+# Buildroot -gf6ca18e-dirty Configuration
 #
 BR2_HAVE_DOT_CONFIG=y
 BR2_HOST_GCC_AT_LEAST_4_9=y
@@ -45,6 +45,7 @@ BR2_x86_64=y
 # BR2_xtensa is not set
 BR2_ARCH_HAS_TOOLCHAIN_BUILDROOT=y
 BR2_ARCH="x86_64"
+BR2_NORMALIZED_ARCH="x86_64"
 BR2_ENDIAN="LITTLE"
 BR2_GCC_TARGET_ARCH="nocona"
 BR2_BINFMT_SUPPORTS_SHARED=y
@@ -54,14 +55,37 @@ BR2_X86_CPU_HAS_MMX=y
 BR2_X86_CPU_HAS_SSE=y
 BR2_X86_CPU_HAS_SSE2=y
 BR2_X86_CPU_HAS_SSE3=y
+# BR2_x86_x86_64 is not set
+# BR2_x86_x86_64_v2 is not set
+# BR2_x86_x86_64_v3 is not set
+# BR2_x86_x86_64_v4 is not set
 BR2_x86_nocona=y
 # BR2_x86_core2 is not set
 # BR2_x86_corei7 is not set
+# BR2_x86_nehalem is not set
 # BR2_x86_westmere is not set
 # BR2_x86_corei7_avx is not set
+# BR2_x86_sandybridge is not set
 # BR2_x86_core_avx2 is not set
+# BR2_x86_haswell is not set
+# BR2_x86_broadwell is not set
+# BR2_x86_skylake is not set
 # BR2_x86_atom is not set
+# BR2_x86_bonnell is not set
 # BR2_x86_silvermont is not set
+# BR2_x86_goldmont is not set
+# BR2_x86_goldmont_plus is not set
+# BR2_x86_tremont is not set
+# BR2_x86_skylake_avx512 is not set
+# BR2_x86_cannonlake is not set
+# BR2_x86_icelake_client is not set
+# BR2_x86_icelake_server is not set
+# BR2_x86_cascadelake is not set
+# BR2_x86_cooperlake is not set
+# BR2_x86_tigerlake is not set
+# BR2_x86_sapphirerapids is not set
+# BR2_x86_alderlake is not set
+# BR2_x86_rocketlake is not set
 # BR2_x86_opteron is not set
 # BR2_x86_opteron_sse3 is not set
 # BR2_x86_barcelona is not set
@@ -82,6 +106,7 @@ BR2_GIT="git"
 BR2_CVS="cvs"
 BR2_LOCALFILES="cp"
 BR2_SCP="scp"
+BR2_SFTP="sftp"
 BR2_HG="hg"
 BR2_ZCAT="gzip -d -c"
 BR2_BZCAT="bzcat"
@@ -107,6 +132,7 @@ BR2_CCACHE_DIR="$(HOME)/.buildroot-ccache"
 BR2_CCACHE_INITIAL_SETUP=""
 BR2_CCACHE_USE_BASEDIR=y
 # BR2_ENABLE_DEBUG is not set
+# BR2_ENABLE_RUNTIME_DEBUG is not set
 BR2_STRIP_strip=y
 BR2_STRIP_EXCLUDE_FILES=""
 BR2_STRIP_EXCLUDE_DIRS=""
@@ -134,6 +160,7 @@ BR2_COMPILER_PARANOID_UNSAFE_PATH=y
 #
 # Security Hardening Options
 #
+BR2_PIC_PIE_ARCH_SUPPORTS=y
 
 #
 # Stack Smashing Protection needs a toolchain w/ SSP
@@ -142,6 +169,7 @@ BR2_COMPILER_PARANOID_UNSAFE_PATH=y
 #
 # RELocation Read Only (RELRO) needs shared libraries
 #
+BR2_FORTIFY_SOURCE_ARCH_SUPPORTS=y
 
 #
 # Fortify Source needs a glibc toolchain and optimization
@@ -176,11 +204,12 @@ BR2_TOOLCHAIN_BUILDROOT_LIBC="uclibc"
 # BR2_KERNEL_HEADERS_4_19 is not set
 # BR2_KERNEL_HEADERS_5_4 is not set
 BR2_KERNEL_HEADERS_5_10=y
+# BR2_KERNEL_HEADERS_5_15 is not set
+# BR2_KERNEL_HEADERS_5_16 is not set
 # BR2_KERNEL_HEADERS_VERSION is not set
 # BR2_KERNEL_HEADERS_CUSTOM_TARBALL is not set
 # BR2_KERNEL_HEADERS_CUSTOM_GIT is not set
-BR2_KERNEL_HEADERS_LATEST=y
-BR2_DEFAULT_KERNEL_HEADERS="5.10.35"
+BR2_DEFAULT_KERNEL_HEADERS="5.10.120"
 BR2_PACKAGE_LINUX_HEADERS=y
 
 #
@@ -192,6 +221,7 @@ BR2_UCLIBC_CONFIG_FRAGMENT_FILES=""
 # BR2_TOOLCHAIN_BUILDROOT_WCHAR is not set
 # BR2_TOOLCHAIN_BUILDROOT_LOCALE is not set
 BR2_PTHREADS_NATIVE=y
+# BR2_PTHREADS is not set
 # BR2_PTHREADS_NONE is not set
 # BR2_PTHREAD_DEBUG is not set
 # BR2_TOOLCHAIN_BUILDROOT_USE_SSP is not set
@@ -203,18 +233,18 @@ BR2_UCLIBC_TARGET_ARCH="x86_64"
 #
 BR2_PACKAGE_HOST_BINUTILS_SUPPORTS_CFI=y
 # BR2_BINUTILS_VERSION_2_32_X is not set
-# BR2_BINUTILS_VERSION_2_34_X is not set
 # BR2_BINUTILS_VERSION_2_35_X is not set
-BR2_BINUTILS_VERSION_2_36_X=y
-BR2_BINUTILS_VERSION="2.36.1"
+# BR2_BINUTILS_VERSION_2_36_X is not set
+BR2_BINUTILS_VERSION_2_37_X=y
+BR2_BINUTILS_VERSION="2.37"
 BR2_BINUTILS_EXTRA_CONFIG_OPTIONS=""
 
 #
 # GCC Options
 #
-# BR2_GCC_VERSION_8_X is not set
 # BR2_GCC_VERSION_9_X is not set
 BR2_GCC_VERSION_10_X=y
+# BR2_GCC_VERSION_11_X is not set
 BR2_GCC_VERSION="10.3.0"
 BR2_EXTRA_GCC_CONFIG_OPTIONS=""
 # BR2_TOOLCHAIN_BUILDROOT_CXX is not set
@@ -296,7 +326,6 @@ BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_7=y
 BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_8=y
 BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_9=y
 BR2_TOOLCHAIN_HEADERS_AT_LEAST_5_10=y
-BR2_TOOLCHAIN_HEADERS_LATEST=y
 BR2_TOOLCHAIN_HEADERS_AT_LEAST="5.10"
 BR2_TOOLCHAIN_GCC_AT_LEAST_4_3=y
 BR2_TOOLCHAIN_GCC_AT_LEAST_4_4=y
@@ -371,6 +400,7 @@ BR2_SYSTEM_DEFAULT_PATH="/bin:/sbin:/usr/bin:/usr/sbin"
 # BR2_TARGET_TZ_INFO is not set
 BR2_ROOTFS_USERS_TABLES=""
 BR2_ROOTFS_OVERLAY=""
+BR2_ROOTFS_PRE_BUILD_SCRIPT=""
 BR2_ROOTFS_POST_BUILD_SCRIPT=""
 BR2_ROOTFS_POST_FAKEROOT_SCRIPT=""
 BR2_ROOTFS_POST_IMAGE_SCRIPT=""
@@ -406,7 +436,7 @@ BR2_PACKAGE_SKELETON_INIT_NONE=y
 # BR2_PACKAGE_AUMIX is not set
 
 #
-# bluez-alsa needs a toolchain w/ wchar, NPTL, headers >= 3.4, dynamic library
+# bluez-alsa needs a toolchain w/ wchar, NPTL, headers >= 3.4, dynamic library, gcc >= 4.9
 #
 # BR2_PACKAGE_DVBLAST is not set
 # BR2_PACKAGE_DVDAUTHOR is not set
@@ -432,7 +462,7 @@ BR2_PACKAGE_FFMPEG_ARCH_SUPPORTS=y
 # BR2_PACKAGE_FLUID_SOUNDFONT is not set
 
 #
-# fluidsynth needs a toolchain w/ threads, wchar, dynamic library
+# fluidsynth needs a toolchain w/ threads, wchar, dynamic library, C++
 #
 
 #
@@ -453,11 +483,11 @@ BR2_PACKAGE_FFMPEG_ARCH_SUPPORTS=y
 BR2_PACKAGE_KODI_ARCH_SUPPORTS=y
 
 #
-# kodi needs python w/ .py modules, a uClibc or glibc toolchain w/ C++, threads, wchar, dynamic library, gcc >= 4.8
+# kodi needs python3 w/ .py modules, a uClibc or glibc toolchain w/ C++, threads, wchar, dynamic library, gcc >= 4.9
 #
 
 #
-# kodi needs an OpenGL EGL backend with OpenGL support
+# kodi needs an OpenGL EGL backend with OpenGL or GLES support
 #
 # BR2_PACKAGE_LAME is not set
 # BR2_PACKAGE_MADPLAY is not set
@@ -482,7 +512,7 @@ BR2_PACKAGE_MJPEGTOOLS_SIMD_SUPPORT=y
 # BR2_PACKAGE_MOTION is not set
 
 #
-# mpd needs a toolchain w/ C++, threads, wchar, gcc >= 7, host gcc >= 7
+# mpd needs a toolchain w/ C++, threads, wchar, gcc >= 8, host gcc >= 8
 #
 # BR2_PACKAGE_MPD_MPC is not set
 # BR2_PACKAGE_MPG123 is not set
@@ -542,6 +572,10 @@ BR2_PACKAGE_PULSEAUDIO_HAS_ATOMIC=y
 #
 
 #
+# zynaddsubfx needs a toolchain w/ C++11 and threads
+#
+
+#
 # Compressors and decompressors
 #
 # BR2_PACKAGE_BROTLI is not set
@@ -584,6 +618,11 @@ BR2_PACKAGE_ZSTD=y
 #
 # bonnie++ needs a toolchain w/ C++
 #
+BR2_PACKAGE_BPFTOOL_ARCH_SUPPORTS=y
+
+#
+# bpftool needs a uClibc or glibc toolchain w/ wchar, dynamic library, threads, headers >= 4.12
+#
 # BR2_PACKAGE_CACHE_CALIBRATOR is not set
 
 #
@@ -612,7 +651,7 @@ BR2_PACKAGE_DELVE_ARCH_SUPPORTS=y
 #
 
 #
-# fio needs a toolchain w/ dynamic library, threads
+# fio needs a toolchain w/ dynamic library, threads, gcc >= 4.9
 #
 
 #
@@ -643,6 +682,11 @@ BR2_PACKAGE_KVM_UNIT_TESTS_ARCH_SUPPORTS=y
 
 #
 # latencytop needs a toolchain w/ wchar, threads
+#
+BR2_PACKAGE_LIBBPF_ARCH_SUPPORTS=y
+
+#
+# libbpf needs a uClibc or glibc toolchain w/ wchar, dynamic library, threads, headers >= 4.13
 #
 # BR2_PACKAGE_LMBENCH is not set
 BR2_PACKAGE_LTP_TESTSUITE_ARCH_SUPPORTS=y
@@ -694,6 +738,10 @@ BR2_PACKAGE_PLY_ARCH_SUPPORTS=y
 #
 # ply needs a toolchain w/ dynamic library, headers >= 4.14
 #
+
+#
+# poke needs a toolchain w/ NPTL, wchar
+#
 # BR2_PACKAGE_PV is not set
 
 #
@@ -707,7 +755,11 @@ BR2_PACKAGE_PLY_ARCH_SUPPORTS=y
 # BR2_PACKAGE_RAMSPEED is not set
 
 #
-# rt-tests needs a uClibc or glibc toolchain w/ NPTL, headers >= 3.14, dynamic library
+# rt-tests needs a uClibc or glibc toolchain w/ NPTL, headers >= 4.5, dynamic library
+#
+
+#
+# rwmem needs a toolchain w/ C++, wchar, gcc >= 5
 #
 
 #
@@ -731,15 +783,20 @@ BR2_PACKAGE_TCF_AGENT_ARCH_SUPPORTS=y
 # BR2_PACKAGE_TINYMEMBENCH is not set
 
 #
-# trace-cmd needs a toolchain w/ threads, dynamic library
+# trace-cmd needs a toolchain w/ NPTL, dynamic library
 #
 BR2_PACKAGE_TRINITY_ARCH_SUPPORTS=y
 # BR2_PACKAGE_TRINITY is not set
 # BR2_PACKAGE_UCLIBC_NG_TEST is not set
+BR2_PACKAGE_UFTRACE_ARCH_SUPPORTS=y
+
+#
+# uftrace needs a toolchain w/ NPTL, dynamic library
+#
 BR2_PACKAGE_VALGRIND_ARCH_SUPPORTS=y
 
 #
-# valgrind needs a toolchain w/ dynamic library
+# valgrind needs a toolchain w/ dynamic library, threads
 #
 # BR2_PACKAGE_VMTOUCH is not set
 # BR2_PACKAGE_WHETSTONE is not set
@@ -789,6 +846,7 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 # BR2_PACKAGE_JQ is not set
 # BR2_PACKAGE_LIBTOOL is not set
 # BR2_PACKAGE_MAKE is not set
+# BR2_PACKAGE_MAWK is not set
 # BR2_PACKAGE_PKGCONF is not set
 
 #
@@ -854,6 +912,10 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 #
 # f2fs-tools needs a toolchain w/ wchar
 #
+
+#
+# firmware-utils needs a toolchain w/ dynamic library
+#
 # BR2_PACKAGE_FLASHBENCH is not set
 # BR2_PACKAGE_FSCRYPTCTL is not set
 
@@ -867,6 +929,7 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 # BR2_PACKAGE_GENEXT2FS is not set
 # BR2_PACKAGE_GENPART is not set
 # BR2_PACKAGE_GENROMFS is not set
+# BR2_PACKAGE_GOCRYPTFS is not set
 # BR2_PACKAGE_IMX_USB_LOADER is not set
 # BR2_PACKAGE_MMC_UTILS is not set
 # BR2_PACKAGE_MTD is not set
@@ -895,6 +958,10 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 # unionfs needs a toolchain w/ threads, dynamic library
 #
 # BR2_PACKAGE_XFSPROGS is not set
+
+#
+# zfs needs a Linux kernel to be built
+#
 
 #
 # Fonts, cursors, icons, sounds and themes
@@ -966,7 +1033,7 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 #
 
 #
-# stella needs a toolchain w/ dynamic library, C++, threads, gcc >= 6
+# stella needs a toolchain w/ dynamic library, C++, threads, gcc >= 7
 #
 # BR2_PACKAGE_XORCURSES is not set
 
@@ -979,7 +1046,7 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 #
 
 #
-# cage needs udev, mesa3d w/ EGL and GLES support
+# cage needs udev, EGL w/ Wayland backend and OpenGL ES support
 #
 
 #
@@ -1009,7 +1076,20 @@ BR2_PACKAGE_PROVIDES_HOST_GETTEXT="host-gettext-tiny"
 #
 
 #
+# kmscube needs EGL, GBM and OpenGL ES, and a toolchain w/ thread support
+#
+
+#
 # libva-utils needs a toolchain w/ C++, threads, dynamic library
+#
+BR2_PACKAGE_MIDORI_ARCH_SUPPORTS=y
+
+#
+# midori needs a glibc toolchain w/ C++, wchar, threads, dynamic library, gcc >= 7, host gcc >= 8
+#
+
+#
+# midori needs libgtk3 w/ X11 or wayland backend
 #
 BR2_PACKAGE_NETSURF_ARCH_SUPPORTS=y
 
@@ -1027,15 +1107,16 @@ BR2_PACKAGE_NETSURF_ARCH_SUPPORTS=y
 #
 
 #
-# tesseract-ocr needs a toolchain w/ threads, C++, gcc >= 4.8, dynamic library, wchar
+# tesseract-ocr needs a toolchain w/ threads, C++, gcc >= 7, dynamic library, wchar
 #
+# BR2_PACKAGE_TINIFIER is not set
 
 #
 # Graphic libraries
 #
 
 #
-# cegui needs a toolchain w/ C++, threads, dynamic library, wchar
+# cegui needs a toolchain w/ C++, threads, dynamic library, wchar, gcc >= 5
 #
 
 #
@@ -1061,6 +1142,10 @@ BR2_PACKAGE_NETSURF_ARCH_SUPPORTS=y
 # BR2_PACKAGE_IMAGEMAGICK is not set
 
 #
+# libglvnd needs a toolchain w/ dynamic library, threads
+#
+
+#
 # linux-fusion needs a Linux kernel to be built
 #
 
@@ -1084,6 +1169,7 @@ BR2_PACKAGE_NETSURF_ARCH_SUPPORTS=y
 #
 # sdl2 needs a toolchain w/ dynamic library
 #
+# BR2_PACKAGE_VULKAN_HEADERS is not set
 
 #
 # Other GUIs
@@ -1107,11 +1193,11 @@ BR2_PACKAGE_QT5_JSCORE_AVAILABLE=y
 #
 
 #
-# apitrace needs a toolchain w/ C++, wchar, dynamic library, threads, gcc >= 4.9
+# apitrace needs a toolchain w/ C++, wchar, dynamic library, threads, gcc >= 7
 #
 
 #
-# midori needs libgtk3 and a glibc toolchain w/ C++, gcc >= 7, host gcc >= 4.9
+# mupdf needs a toolchain w/ C++, gcc >= 4.9
 #
 
 #
@@ -1123,7 +1209,7 @@ BR2_PACKAGE_QT5_JSCORE_AVAILABLE=y
 #
 
 #
-# vte needs a toolchain w/ wchar, threads, C++, gcc >= 4.8
+# vte needs a uClibc or glibc toolchain w/ wchar, threads, C++, gcc >= 10
 #
 
 #
@@ -1196,6 +1282,10 @@ BR2_PACKAGE_QT5_JSCORE_AVAILABLE=y
 # dahdi-tools needs a toolchain w/ threads and a Linux kernel to be built
 #
 # BR2_PACKAGE_DBUS is not set
+
+#
+# dbus-cxx needs a toolchain w/ C++, threads, gcc >= 7 and dynamic library support
+#
 # BR2_PACKAGE_DFU_UTIL is not set
 # BR2_PACKAGE_DMIDECODE is not set
 
@@ -1205,6 +1295,10 @@ BR2_PACKAGE_QT5_JSCORE_AVAILABLE=y
 
 #
 # dt-utils needs udev /dev management
+#
+
+#
+# dtbocfg needs a Linux kernel to be built
 #
 # BR2_PACKAGE_DTV_SCAN_TABLES is not set
 # BR2_PACKAGE_DUMP1090 is not set
@@ -1225,6 +1319,7 @@ BR2_PACKAGE_QT5_JSCORE_AVAILABLE=y
 BR2_PACKAGE_FLASHROM_ARCH_SUPPORTS=y
 # BR2_PACKAGE_FLASHROM is not set
 # BR2_PACKAGE_FMTOOLS is not set
+# BR2_PACKAGE_FREEIPMI is not set
 # BR2_PACKAGE_FXLOAD is not set
 
 #
@@ -1247,7 +1342,6 @@ BR2_PACKAGE_FLASHROM_ARCH_SUPPORTS=y
 # BR2_PACKAGE_I7Z is not set
 # BR2_PACKAGE_INPUT_EVENT_DAEMON is not set
 # BR2_PACKAGE_INTEL_MICROCODE is not set
-# BR2_PACKAGE_IOSTAT is not set
 # BR2_PACKAGE_IPMITOOL is not set
 
 #
@@ -1290,6 +1384,10 @@ BR2_PACKAGE_FLASHROM_ARCH_SUPPORTS=y
 
 #
 # lvm2 needs a toolchain w/ threads, dynamic library
+#
+
+#
+# mali-driver needs a Linux kernel to be built
 #
 # BR2_PACKAGE_MBPFAN is not set
 
@@ -1346,6 +1444,7 @@ BR2_PACKAGE_FLASHROM_ARCH_SUPPORTS=y
 # powertop needs a toolchain w/ C++, threads, wchar
 #
 # BR2_PACKAGE_PPS_TOOLS is not set
+# BR2_PACKAGE_QORIQ_CADENCE_DP_FIRMWARE is not set
 # BR2_PACKAGE_RASPI_GPIO is not set
 # BR2_PACKAGE_READ_EDID is not set
 # BR2_PACKAGE_RNG_TOOLS is not set
@@ -1354,6 +1453,10 @@ BR2_PACKAGE_FLASHROM_ARCH_SUPPORTS=y
 
 #
 # rtl8188eu needs a Linux kernel to be built
+#
+
+#
+# rtl8189es needs a Linux kernel to be built
 #
 
 #
@@ -1366,6 +1469,10 @@ BR2_PACKAGE_FLASHROM_ARCH_SUPPORTS=y
 
 #
 # rtl8723bu needs a Linux kernel to be built
+#
+
+#
+# rtl8812au-aircrack-ng needs a Linux kernel to be built
 #
 
 #
@@ -1408,14 +1515,6 @@ BR2_PACKAGE_SEDUTIL_ARCH_SUPPORTS=y
 #
 # targetcli-fb depends on Python
 #
-
-#
-# ti-sgx-um needs the ti-sgx-km driver
-#
-
-#
-# ti-sgx-um needs udev and a glibc toolchain w/ threads
-#
 # BR2_PACKAGE_TI_UIM is not set
 # BR2_PACKAGE_TI_UTILS is not set
 # BR2_PACKAGE_TIO is not set
@@ -1435,7 +1534,7 @@ BR2_PACKAGE_SEDUTIL_ARCH_SUPPORTS=y
 #
 
 #
-# udisks needs a glibc or musl toolchain with locale, C++, wchar, dynamic library, NPTL, gcc >= 4.9
+# udisks needs a toolchain with dynamic library, locale, wchar, threads, gcc >= 7
 #
 # BR2_PACKAGE_UHUBCTL is not set
 # BR2_PACKAGE_UMTPRD is not set
@@ -1449,6 +1548,10 @@ BR2_PACKAGE_SEDUTIL_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_USB_MODESWITCH is not set
 # BR2_PACKAGE_USB_MODESWITCH_DATA is not set
+
+#
+# usbguard needs a glibc or uClibc toolchain w/ C++, threads, dynamic library, gcc >= 4.8
+#
 
 #
 # usbmount requires udev to be enabled
@@ -1491,6 +1594,7 @@ BR2_PACKAGE_GAUCHE_ARCH_SUPPORTS=y
 # guile needs a uClibc or glibc toolchain w/ threads, wchar, dynamic library
 #
 # BR2_PACKAGE_HASERL is not set
+# BR2_PACKAGE_JANET is not set
 # BR2_PACKAGE_JIMTCL is not set
 # BR2_PACKAGE_LUA is not set
 BR2_PACKAGE_PROVIDES_HOST_LUAINTERPRETER="host-lua"
@@ -1511,12 +1615,12 @@ BR2_PACKAGE_HOST_MONO_ARCH_SUPPORTS=y
 BR2_PACKAGE_MONO_ARCH_SUPPORTS=y
 
 #
-# mono needs a toolchain w/ C++, threads, dynamic library
+# mono needs a toolchain w/ C++, NPTL, dynamic library
 #
 BR2_PACKAGE_NODEJS_ARCH_SUPPORTS=y
 
 #
-# nodejs needs a toolchain w/ C++, dynamic library, NPTL, gcc >= 4.9, wchar
+# nodejs needs a toolchain w/ C++, dynamic library, NPTL, gcc >= 7, wchar, host gcc >= 8
 #
 BR2_PACKAGE_HOST_OPENJDK_BIN_ARCH_SUPPORTS=y
 BR2_PACKAGE_OPENJDK_ARCH_SUPPORTS=y
@@ -1526,13 +1630,12 @@ BR2_PACKAGE_OPENJDK_ARCH_SUPPORTS=y
 #
 
 #
-# openjdk needs glibc, and a toolchain w/ wchar, dynamic library, threads, C++, gcc >= 4.9
+# openjdk needs glibc, and a toolchain w/ wchar, dynamic library, threads, C++, gcc >= 4.9, host gcc >= 4.9
 #
 # BR2_PACKAGE_PERL is not set
-# BR2_PACKAGE_PHP is not set
 
 #
-# python needs a toolchain w/ wchar, threads, dynamic library
+# php needs a toolchain w/ wchar
 #
 
 #
@@ -1544,7 +1647,7 @@ BR2_PACKAGE_OPENJDK_ARCH_SUPPORTS=y
 #
 
 #
-# ruby needs a toolchain w/ wchar, threads, dynamic library
+# ruby needs a toolchain w/ wchar, threads, dynamic library, gcc >= 4.9, host gcc >= 4.9
 #
 
 #
@@ -1628,7 +1731,12 @@ BR2_PACKAGE_FDK_AAC_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBVORBIS is not set
 
 #
-# mp4v2 needs a toolchain w/ C++
+# lilv needs a toolchain w/ dynamic library
+#
+# BR2_PACKAGE_LV2 is not set
+
+#
+# mp4v2 needs a toolchain w/ C++, gcc >= 5
 #
 BR2_PACKAGE_OPENAL_ARCH_SUPPORTS=y
 
@@ -1646,6 +1754,7 @@ BR2_PACKAGE_OPENAL_ARCH_SUPPORTS=y
 # BR2_PACKAGE_SPANDSP is not set
 # BR2_PACKAGE_SPEEX is not set
 # BR2_PACKAGE_SPEEXDSP is not set
+# BR2_PACKAGE_SRATOM is not set
 
 #
 # taglib needs a toolchain w/ C++, wchar
@@ -1689,6 +1798,7 @@ BR2_PACKAGE_WEBRTC_AUDIO_PROCESSING_ARCH_SUPPORTS=y
 # snappy needs a toolchain w/ C++
 #
 # BR2_PACKAGE_SZIP is not set
+# BR2_PACKAGE_ZCHUNK is not set
 BR2_PACKAGE_ZLIB_NG_ARCH_SUPPORTS=y
 # BR2_PACKAGE_ZLIB is not set
 BR2_PACKAGE_PROVIDES_HOST_ZLIB="host-libzlib"
@@ -1711,6 +1821,10 @@ BR2_PACKAGE_BOTAN_ARCH_SUPPORTS=y
 #
 
 #
+# cryptopp needs a toolchain w/ C++, dynamic library, wchar
+#
+
+#
 # gcr needs a toolchain w/ wchar, threads, dynamic library
 #
 
@@ -1729,7 +1843,7 @@ BR2_PACKAGE_LIBGPG_ERROR_SYSCFG="x86_64-unknown-linux-gnu"
 # BR2_PACKAGE_LIBGPGME is not set
 # BR2_PACKAGE_LIBKCAPI is not set
 # BR2_PACKAGE_LIBKSBA is not set
-# BR2_PACKAGE_LIBMCRYPT is not set
+# BR2_PACKAGE_LIBMD is not set
 # BR2_PACKAGE_LIBMHASH is not set
 
 #
@@ -1763,9 +1877,9 @@ BR2_PACKAGE_LIBGPG_ERROR_SYSCFG="x86_64-unknown-linux-gnu"
 #
 # libuecc needs a toolchain w/ dynamic library
 #
+# BR2_PACKAGE_LIBXCRYPT is not set
 # BR2_PACKAGE_MBEDTLS is not set
 # BR2_PACKAGE_NETTLE is not set
-BR2_PACKAGE_LIBOPENSSL_ARCH_SUPPORTS=y
 # BR2_PACKAGE_OPENSSL is not set
 BR2_PACKAGE_PROVIDES_HOST_OPENSSL="host-libopenssl"
 
@@ -1796,7 +1910,10 @@ BR2_PACKAGE_PROVIDES_HOST_OPENSSL="host-libopenssl"
 # Database
 #
 # BR2_PACKAGE_BERKELEYDB is not set
-# BR2_PACKAGE_GDBM is not set
+
+#
+# gdbm needs a toolchain w/ wchar
+#
 # BR2_PACKAGE_HIREDIS is not set
 
 #
@@ -1805,6 +1922,14 @@ BR2_PACKAGE_PROVIDES_HOST_OPENSSL="host-libopenssl"
 
 #
 # leveldb needs a toolchain w/ C++, threads, gcc >= 4.8
+#
+
+#
+# libdbi needs a toolchain w/ dynamic library
+#
+
+#
+# libdbi-drivers needs a toolchain w/ dynamic library
 #
 
 #
@@ -1832,6 +1957,7 @@ BR2_PACKAGE_MONGODB_ARCH_SUPPORTS=y
 #
 # redis needs a toolchain w/ gcc>=4.9, dynamic library, nptl
 #
+BR2_PACKAGE_ROCKSDB_ARCH_SUPPORTS=y
 
 #
 # rocksdb needs a toolchain w/ C++, threads, wchar, gcc >= 4.8
@@ -1898,16 +2024,16 @@ BR2_PACKAGE_MONGODB_ARCH_SUPPORTS=y
 #
 
 #
-# atkmm needs a toolchain w/ C++, wchar, threads, gcc >= 4.9
+# atkmm needs a toolchain w/ C++, wchar, threads, gcc >= 7
 #
 
 #
-# bullet needs a toolchain w/ C++
+# bullet needs a toolchain w/ C++, dynamic library, threads, wchar
 #
 # BR2_PACKAGE_CAIRO is not set
 
 #
-# cairomm needs a toolchain w/ C++, wchar, threads, gcc >= 4.8
+# cairomm needs a toolchain w/ C++, wchar, threads, gcc >= 7
 #
 
 #
@@ -1935,7 +2061,7 @@ BR2_PACKAGE_MONGODB_ARCH_SUPPORTS=y
 # BR2_PACKAGE_GIFLIB is not set
 
 #
-# granite needs libgtk3 and a toolchain w/ wchar, threads
+# granite needs libgtk3 and a toolchain w/ wchar, threads, gcc >= 4.9
 #
 
 #
@@ -1943,11 +2069,11 @@ BR2_PACKAGE_MONGODB_ARCH_SUPPORTS=y
 #
 
 #
-# gtkmm3 needs libgtk3 and a toolchain w/ C++, wchar, threads, gcc >= 4.9
+# gtkmm3 needs libgtk3 and a toolchain w/ C++, wchar, threads, gcc >= 7
 #
 
 #
-# harfbuzz needs a toolchain w/ C++, gcc >= 4.8
+# harfbuzz needs a toolchain w/ C++, gcc >= 4.9
 #
 # BR2_PACKAGE_IJS is not set
 
@@ -1956,19 +2082,11 @@ BR2_PACKAGE_MONGODB_ARCH_SUPPORTS=y
 #
 
 #
-# intel-gmmlib needs a toolchain w/ dynamic library
-#
-
-#
-# intel-mediadriver needs X.org
+# intel-gmmlib needs a toolchain w/ dynamic library, C++
 #
 
 #
 # intel-mediadriver needs a toolchain w/ dynamic library, C++, NPTL
-#
-
-#
-# intel-mediasdk needs X.org
 #
 
 #
@@ -2002,7 +2120,7 @@ BR2_PACKAGE_JPEG_SIMD_SUPPORT=y
 # BR2_PACKAGE_LIBEXIF is not set
 
 #
-# libfm needs X.org and a toolchain w/ wchar, threads, C++, gcc >= 4.8
+# libfm needs X.org and a toolchain w/ wchar, threads, C++, gcc >= 4.9
 #
 
 #
@@ -2026,7 +2144,7 @@ BR2_PACKAGE_JPEG_SIMD_SUPPORT=y
 #
 
 #
-# libglfw depends on X.org and needs an OpenGL backend
+# libglfw depends on X.org or Wayland and an OpenGL or GLES backend
 #
 
 #
@@ -2035,7 +2153,7 @@ BR2_PACKAGE_JPEG_SIMD_SUPPORT=y
 # BR2_PACKAGE_LIBGTA is not set
 
 #
-# libgtk3 needs a toolchain w/ wchar, threads, C++, gcc >= 4.8
+# libgtk3 needs a toolchain w/ wchar, threads, C++, gcc >= 4.9
 #
 
 #
@@ -2051,10 +2169,6 @@ BR2_PACKAGE_JPEG_SIMD_SUPPORT=y
 
 #
 # libraw needs a toolchain w/ C++
-#
-
-#
-# libsoil needs an OpenGL backend and a toolchain w/ dynamic library
 #
 # BR2_PACKAGE_LIBSVG is not set
 # BR2_PACKAGE_LIBSVG_CAIRO is not set
@@ -2083,23 +2197,27 @@ BR2_PACKAGE_JPEG_SIMD_SUPPORT=y
 #
 # opencv3 needs a toolchain w/ C++, NPTL, wchar, dynamic library
 #
+
+#
+# opencv4 needs a toolchain w/ C++, NPTL, wchar, dynamic library, gcc >= 4.8
+#
 # BR2_PACKAGE_OPENJPEG is not set
 
 #
-# pango needs a toolchain w/ wchar, threads, C++, gcc >= 4.8
+# pango needs a toolchain w/ wchar, threads, C++, gcc >= 4.9
 #
 
 #
-# pangomm needs a toolchain w/ C++, wchar, threads, gcc >= 4.9
+# pangomm needs a toolchain w/ C++, wchar, threads, gcc >= 7
 #
 
 #
-# pipewire needs udev and a toolchain w/ threads, headers >= 3.18
+# pipewire needs a toolchain w/ dynamic library, NTPL, gcc >= 5
 #
 # BR2_PACKAGE_PIXMAN is not set
 
 #
-# poppler needs a toolchain w/ wchar, C++, threads, dynamic library, gcc >= 5
+# poppler needs a toolchain w/ wchar, C++, threads, dynamic library, gcc >= 7
 #
 # BR2_PACKAGE_TIFF is not set
 
@@ -2109,12 +2227,12 @@ BR2_PACKAGE_JPEG_SIMD_SUPPORT=y
 BR2_PACKAGE_WEBKITGTK_ARCH_SUPPORTS=y
 
 #
-# webkitgtk needs libgtk3 and a glibc toolchain w/ C++, gcc >= 7, host gcc >= 4.9
+# webkitgtk needs libgtk3 and a toolchain w/ C++, wchar, threads, dynamic library, gcc >= 7, host gcc >= 4.9
 #
 # BR2_PACKAGE_WEBP is not set
 
 #
-# wlroots needs udev, mesa3d w/ EGL and GLES support
+# wlroots needs udev, EGL w/ Wayland backend and OpenGL ES support
 #
 
 #
@@ -2223,11 +2341,15 @@ BR2_PACKAGE_GNU_EFI_ARCH_SUPPORTS=y
 #
 
 #
-# libpri needs a kernel to be built
+# libpri needs a Linux kernel to be built
 #
 
 #
 # libqmi needs a toolchain w/ wchar, threads
+#
+
+#
+# libqrtr-glib needs a toolchain w/ wchar, threads, headers >= 4.15
 #
 # BR2_PACKAGE_LIBRAW1394 is not set
 # BR2_PACKAGE_LIBRTLSDR is not set
@@ -2247,7 +2369,7 @@ BR2_PACKAGE_GNU_EFI_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBSOC is not set
 
 #
-# libss7 needs a kernel to be built
+# libss7 needs a Linux kernel to be built
 #
 # BR2_PACKAGE_LIBUSB is not set
 # BR2_PACKAGE_LIBUSBGX is not set
@@ -2300,12 +2422,6 @@ BR2_PACKAGE_MRAA_ARCH_SUPPORTS=y
 # BR2_PACKAGE_JSZIP is not set
 # BR2_PACKAGE_OPENLAYERS is not set
 # BR2_PACKAGE_POPPERJS is not set
-BR2_PACKAGE_SPIDERMONKEY_ARCH_SUPPORTS=y
-BR2_PACKAGE_SPIDERMONKEY_JIT_ARCH_SUPPORTS=y
-
-#
-# spidermonkey needs a glibc or musl toolchain with C++, wchar, dynamic library, NPTL, gcc >= 4.9
-#
 # BR2_PACKAGE_VUEJS is not set
 
 #
@@ -2344,7 +2460,7 @@ BR2_PACKAGE_SPIDERMONKEY_JIT_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBXML2 is not set
 
 #
-# libxml++ needs a toolchain w/ C++, wchar, threads, gcc >= 4.9
+# libxml++ needs a toolchain w/ C++, wchar, threads, gcc >= 7
 #
 # BR2_PACKAGE_LIBXMLRPC is not set
 # BR2_PACKAGE_LIBXSLT is not set
@@ -2360,6 +2476,8 @@ BR2_PACKAGE_SPIDERMONKEY_JIT_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_RAPIDXML is not set
 # BR2_PACKAGE_RAPTOR is not set
+# BR2_PACKAGE_SERD is not set
+# BR2_PACKAGE_SORD is not set
 
 #
 # tinyxml needs a toolchain w/ C++
@@ -2370,11 +2488,15 @@ BR2_PACKAGE_SPIDERMONKEY_JIT_ARCH_SUPPORTS=y
 #
 
 #
-# valijson needs a toolchain w/ C++, threads, wchar  support
+# valijson needs a toolchain w/ C++
 #
 
 #
-# xerces-c++ needs a toolchain w/ C++, wchar
+# xerces-c++ needs a toolchain w/ C++, dynamic library, wchar
+#
+
+#
+# xml-security-c needs a toolchain w/ C++, wchar, dynamic library, threads, gcc >= 4.7
 #
 # BR2_PACKAGE_YAJL is not set
 
@@ -2405,6 +2527,10 @@ BR2_PACKAGE_SPIDERMONKEY_JIT_ARCH_SUPPORTS=y
 #
 
 #
+# log4qt needs qt5
+#
+
+#
 # opentracing-cpp needs a toolchain w/ C++, threads, dynamic library, gcc >= 4.8
 #
 
@@ -2413,11 +2539,19 @@ BR2_PACKAGE_SPIDERMONKEY_JIT_ARCH_SUPPORTS=y
 #
 
 #
+# ulog needs a toolchain w/ C++, threads
+#
+
+#
 # zlog needs a toolchain w/ threads, dynamic library
 #
 
 #
 # Multimedia
+#
+
+#
+# bento4 support needs a toolchain with C++
 #
 # BR2_PACKAGE_BITSTREAM is not set
 
@@ -2434,7 +2568,7 @@ BR2_PACKAGE_SPIDERMONKEY_JIT_ARCH_SUPPORTS=y
 #
 
 #
-# libass needs a toolchain w/ C++, gcc >= 4.8
+# libass needs a toolchain w/ C++, gcc >= 4.9
 #
 
 #
@@ -2448,6 +2582,10 @@ BR2_PACKAGE_LIBCAMERA_ARCH_SUPPORTS=y
 
 #
 # libcamera needs a toolchain w/ C++, threads, wchar, dynamic library, gcc >= 7
+#
+
+#
+# libcamera-apps needs a toolchain w/ C++, threads, wchar, dynamic library, gcc >= 7
 #
 # BR2_PACKAGE_LIBDCADEC is not set
 # BR2_PACKAGE_LIBDVBCSA is not set
@@ -2477,6 +2615,10 @@ BR2_PACKAGE_LIBCAMERA_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_LIBMPEG2 is not set
 # BR2_PACKAGE_LIBOGG is not set
+
+#
+# libopenaptx needs a toolchain w/ dynamic library
+#
 BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 
 #
@@ -2513,7 +2655,7 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 #
 
 #
-# azmq needs a toolchain w/ C++11, wchar and NPTL
+# azmq needs a toolchain w/ C++11, wchar and threads
 #
 
 #
@@ -2528,11 +2670,6 @@ BR2_PACKAGE_LIBOPENH264_ARCH_SUPPORTS=y
 # belle-sip needs a toolchain w/ threads, C++, dynamic library, wchar
 #
 # BR2_PACKAGE_C_ARES is not set
-BR2_PACKAGE_CANFESTIVAL_ARCH_SUPPORTS=y
-
-#
-# canfestival needs a glibc or uClibc toolchain w/ threads and dynamic library
-#
 # BR2_PACKAGE_CGIC is not set
 
 #
@@ -2549,6 +2686,10 @@ BR2_PACKAGE_CANFESTIVAL_ARCH_SUPPORTS=y
 
 #
 # daq needs a toolchain w/ dynamic library
+#
+
+#
+# daq3 needs a toolchain w/ dynamic library, gcc >= 4.9, threads
 #
 
 #
@@ -2569,7 +2710,7 @@ BR2_PACKAGE_CANFESTIVAL_ARCH_SUPPORTS=y
 #
 
 #
-# grpc needs a toolchain w/ C++, threads, dynamic library, gcc >= 4.9, host gcc >= 4.9
+# grpc needs a toolchain w/ C++, threads, dynamic library, gcc >= 4.9
 #
 
 #
@@ -2608,6 +2749,10 @@ BR2_PACKAGE_CANFESTIVAL_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBCURL is not set
 # BR2_PACKAGE_LIBDNET is not set
 # BR2_PACKAGE_LIBEXOSIP2 is not set
+
+#
+# libest needs a toolchain w/ dynamic library
+#
 # BR2_PACKAGE_LIBFCGI is not set
 
 #
@@ -2645,7 +2790,7 @@ BR2_PACKAGE_CANFESTIVAL_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBMODBUS is not set
 
 #
-# libmodsecurity needs a toolchain w/ C++, dynamic library, threads
+# libmodsecurity needs a toolchain w/ C++, threads
 #
 
 #
@@ -2688,6 +2833,10 @@ BR2_PACKAGE_LIBNL=y
 #
 # libpjsip needs a toolchain w/ C++, threads
 #
+
+#
+# libpsl needs a toolchain w/ wchar
+#
 # BR2_PACKAGE_LIBRELP is not set
 # BR2_PACKAGE_LIBRSYNC is not set
 
@@ -2702,6 +2851,10 @@ BR2_PACKAGE_LIBNL=y
 #
 # BR2_PACKAGE_LIBSRTP is not set
 # BR2_PACKAGE_LIBSTROPHE is not set
+
+#
+# libteam needs MMU and a toolchain w/ dynamic library and threads
+#
 # BR2_PACKAGE_LIBTELNET is not set
 # BR2_PACKAGE_LIBTIRPC is not set
 
@@ -2714,6 +2867,10 @@ BR2_PACKAGE_LIBNL=y
 #
 # BR2_PACKAGE_LIBUEV is not set
 # BR2_PACKAGE_LIBUHTTPD is not set
+
+#
+# libuhttpd needs a toolchain w/ gcc >= 4.9
+#
 # BR2_PACKAGE_LIBUPNP is not set
 
 #
@@ -2794,11 +2951,11 @@ BR2_PACKAGE_LIBNL=y
 #
 
 #
-# pistache needs a glibc toolchain w/ C++, gcc >= 4.9, threads, wchar
+# pistache needs a glibc toolchain w/ C++, gcc >= 4.9, threads, wchar, not binutils bug 27597
 #
 
 #
-# qpid-proton needs a toolchain w/ dynamic library
+# qpid-proton needs a toolchain w/ C++, dynamic library, threads
 #
 
 #
@@ -2813,6 +2970,7 @@ BR2_PACKAGE_LIBNL=y
 # restclient-cpp needs a toolchain w/ C++, gcc >= 4.8
 #
 # BR2_PACKAGE_RTMPDUMP is not set
+# BR2_PACKAGE_SIPROXD is not set
 
 #
 # slirp needs a toolchain w/ wchar, threads
@@ -2854,6 +3012,10 @@ BR2_PACKAGE_LIBNL=y
 
 #
 # Other
+#
+
+#
+# ACE needs a glibc toolchain, dynamic library, C++, gcc >= 4.8
 #
 
 #
@@ -2909,7 +3071,6 @@ BR2_PACKAGE_LIBNL=y
 #
 # clang needs a toolchain w/ wchar, threads, C++, gcc >= 4.8, dynamic library
 #
-# BR2_PACKAGE_CLAPACK is not set
 
 #
 # cmocka needs a toolchain w/ dynamic library
@@ -2960,7 +3121,7 @@ BR2_PACKAGE_LIBNL=y
 #
 
 #
-# glibmm needs a toolchain w/ C++, wchar, threads, gcc >= 4.9
+# glibmm needs a toolchain w/ C++, wchar, threads, gcc >= 7
 #
 
 #
@@ -2974,15 +3135,17 @@ BR2_PACKAGE_GOBJECT_INTROSPECTION_ARCH_SUPPORTS=y
 #
 
 #
-# gobject-introspection needs a glibc toolchain, gcc >= 4.9
+# gobject-introspection needs a glibc toolchain, gcc >= 4.9, host gcc >= 8
 #
 # BR2_PACKAGE_GSL is not set
 
 #
-# gtest needs a toolchain w/ C++, wchar, threads
+# gtest needs a toolchain w/ C++, wchar, threads, gcc >= 4.9
 #
+# BR2_PACKAGE_GUMBO_PARSER is not set
 BR2_PACKAGE_JEMALLOC_ARCH_SUPPORTS=y
 # BR2_PACKAGE_JEMALLOC is not set
+BR2_PACKAGE_LAPACK_ARCH_SUPPORTS=y
 
 #
 # lapack/blas needs a toolchain w/ fortran
@@ -3033,14 +3196,22 @@ BR2_PACKAGE_LIBEASTL_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBEV is not set
 # BR2_PACKAGE_LIBEVDEV is not set
 # BR2_PACKAGE_LIBEVENT is not set
+
+#
+# libexecinfo needs a musl or uclibc toolchain w/ dynamic library
+#
 # BR2_PACKAGE_LIBFFI is not set
 
 #
-# libgee needs a toolchain w/ wchar, threads
+# libfutils needs a toolchain w/ C++, threads
 #
 
 #
-# libgeos needs a toolchain w/ C++, wchar, not binutils bug 21464, 27597
+# libgee needs a toolchain w/ wchar, threads, gcc >= 4.9
+#
+
+#
+# libgeos needs a toolchain w/ C++, wchar, threads not binutils bug 27597
 #
 
 #
@@ -3052,6 +3223,10 @@ BR2_PACKAGE_LIBEASTL_ARCH_SUPPORTS=y
 # libical needs a toolchain w/ C++, dynamic library, wchar
 #
 # BR2_PACKAGE_LIBITE is not set
+
+#
+# libks needs a toolchain w/ C++, NPTL, dynamic library
+#
 
 #
 # liblinear needs a toolchain w/ C++
@@ -3066,6 +3241,18 @@ BR2_PACKAGE_LIBNSPR_ARCH_SUPPORT=y
 #
 # libnspr needs a toolchain w/ threads, dynamic library
 #
+
+#
+# libosmium needs a toolchain w/ C++,  wchar, threads, gcc >= 4.7
+#
+
+#
+# libpeas needs python3
+#
+
+#
+# libpeas needs a glibc toolchain, gcc >= 4.9, host gcc >= 8
+#
 # BR2_PACKAGE_LIBPFM4 is not set
 
 #
@@ -3074,17 +3261,29 @@ BR2_PACKAGE_LIBNSPR_ARCH_SUPPORT=y
 # BR2_PACKAGE_LIBPTHREAD_STUBS is not set
 # BR2_PACKAGE_LIBPTHSEM is not set
 # BR2_PACKAGE_LIBPWQUALITY is not set
+
+#
+# libqb needs a toolchain w/ threads, dynamic library
+#
 BR2_PACKAGE_LIBSECCOMP_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBSECCOMP is not set
 
 #
-# libsigc++ needs a toolchain w/ C++, gcc >= 4.8
+# libshdata needs a toolchain w/ C++, threads
+#
+
+#
+# libsigc++ needs a toolchain w/ C++, gcc >= 7
 #
 BR2_PACKAGE_LIBSIGSEGV_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBSIGSEGV is not set
 
 #
 # libspatialindex needs a toolchain w/ C++, gcc >= 4.7
+#
+
+#
+# libtalloc needs a toolchain w/ dynamic library
 #
 # BR2_PACKAGE_LIBTASN1 is not set
 # BR2_PACKAGE_LIBTOMMATH is not set
@@ -3104,6 +3303,7 @@ BR2_PACKAGE_LIBUNWIND_ARCH_SUPPORTS=y
 #
 BR2_PACKAGE_LIBURCU_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBURCU is not set
+# BR2_PACKAGE_LIBURING is not set
 
 #
 # libuv needs a toolchain w/ NPTL, dynamic library
@@ -3164,7 +3364,11 @@ BR2_PACKAGE_PROTOBUF_ARCH_SUPPORTS=y
 #
 
 #
-# qhull needs a toolchain w/ C++, dynamic library, gcc >= 4.4
+# protozero needs a toolchain w/ C++,  gcc >= 4.7
+#
+
+#
+# qhull needs a toolchain w/ C++, gcc >= 4.4
 #
 
 #
@@ -3196,14 +3400,18 @@ BR2_PACKAGE_PROTOBUF_ARCH_SUPPORTS=y
 # BR2_PACKAGE_LIBAPPARMOR is not set
 
 #
-# libselinux needs a toolchain w/ threads, dynamic library
+# libselinux needs a toolchain w/ threads, dynamic library, gcc >= 5
 #
 
 #
-# libsemanage needs a toolchain w/ threads, dynamic library
+# libsemanage needs a toolchain w/ threads, dynamic library, gcc >= 5
 #
 # BR2_PACKAGE_LIBSEPOL is not set
 # BR2_PACKAGE_SAFECLIB is not set
+
+#
+# softhsm2 needs a toolchain w/ C++, threads, gcc >= 4.8 and dynamic library support
+#
 
 #
 # Text and terminal handling
@@ -3308,7 +3516,7 @@ BR2_PACKAGE_BITCOIN_ARCH_SUPPORTS=y
 # BR2_PACKAGE_COLLECTL is not set
 
 #
-# domoticz needs lua 5.3 and a toolchain w/ C++, gcc >= 4.8, NPTL, wchar, dynamic library
+# domoticz needs lua 5.3 and a toolchain w/ C++, gcc >= 6, NPTL, wchar, dynamic library
 #
 # BR2_PACKAGE_EMPTY is not set
 
@@ -3330,7 +3538,6 @@ BR2_PACKAGE_BITCOIN_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_HAVEGED is not set
 # BR2_PACKAGE_LINUX_SYSCALL_SUPPORT is not set
-# BR2_PACKAGE_MCRYPT is not set
 # BR2_PACKAGE_MOBILE_BROADBAND_PROVIDER_INFO is not set
 
 #
@@ -3343,11 +3550,15 @@ BR2_PACKAGE_BITCOIN_ARCH_SUPPORTS=y
 BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
 
 #
-# QEMU requires a toolchain with wchar, threads
+# QEMU requires a toolchain with wchar, threads, gcc >= 8
 #
 
 #
-# qpdf needs a toolchain w/ C++, wchar, gcc >= 4.7
+# qpdf needs a toolchain w/ C++, gcc >= 5
+#
+
+#
+# rtl_433 needs a toolchain w/ dynamic library, threads
 #
 
 #
@@ -3361,6 +3572,10 @@ BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
 #
 # taskd needs a toolchain w/ C++, wchar, dynamic library
 #
+
+#
+# xmrig needs a glibc or musl toolchain w/ NPTL, dynamic library, C++
+#
 # BR2_PACKAGE_XUTIL_UTIL_MACROS is not set
 
 #
@@ -3369,6 +3584,10 @@ BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
 
 #
 # aircrack-ng needs a toolchain w/ dynamic library, threads, C++
+#
+
+#
+# alfred needs a toolchain w/ dynamic library, threads
 #
 # BR2_PACKAGE_AOETOOLS is not set
 
@@ -3391,7 +3610,10 @@ BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
 #
 # bcusdk needs a toolchain w/ C++
 #
-# BR2_PACKAGE_BIND is not set
+
+#
+# bind needs a toolchain w/ NPTL, dynamic library
+#
 # BR2_PACKAGE_BIRD is not set
 
 #
@@ -3400,7 +3622,11 @@ BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
 # BR2_PACKAGE_BMON is not set
 
 #
-# boinc needs a toolchain w/ dynamic library, C++, threads
+# bmx7 needs a toolchain with dynamic library support
+#
+
+#
+# boinc needs a toolchain w/ dynamic library, C++, threads, gcc >= 4.8
 #
 # BR2_PACKAGE_BRCM_PATCHRAM_PLUS is not set
 # BR2_PACKAGE_BRIDGE_UTILS is not set
@@ -3418,6 +3644,7 @@ BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
 #
 # casync needs a glibc toolchain
 #
+# BR2_PACKAGE_CFM is not set
 # BR2_PACKAGE_CHRONY is not set
 # BR2_PACKAGE_CIVETWEB is not set
 
@@ -3447,7 +3674,11 @@ BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
 #
 
 #
-# cups-filters needs a toolchain w/ wchar, C++, threads and dynamic library, gcc >= 4.8
+# cups-filters needs a toolchain w/ wchar, C++, threads and dynamic library, gcc >= 5
+#
+
+#
+# cups-pk-helper support needs a toolchain with threads, wchar, dynamic library, gcc >= 7
 #
 # BR2_PACKAGE_DANTE is not set
 # BR2_PACKAGE_DARKHTTPD is not set
@@ -3485,7 +3716,7 @@ BR2_PACKAGE_QEMU_ARCH_SUPPORTS_TARGET=y
 #
 
 #
-# gerbera needs a toolchain w/ C++, threads, wchar, gcc >= 8
+# gerbera needs a toolchain w/ C++, dynamic library, threads, wchar, gcc >= 8
 #
 
 #
@@ -3582,9 +3813,13 @@ BR2_PACKAGE_IPTABLES=y
 #
 
 #
-# kismet needs a toolchain w/ threads, C++
+# kismet needs a toolchain w/ threads, C++, gcc >= 5
 #
 # BR2_PACKAGE_KNOCK is not set
+
+#
+# ksmbd-tools needs a toolchain w/ wchar, threads
+#
 # BR2_PACKAGE_LEAFNODE2 is not set
 # BR2_PACKAGE_LFT is not set
 
@@ -3636,15 +3871,12 @@ BR2_PACKAGE_MONGREL2_LIBC_SUPPORTS=y
 #
 
 #
-# monkey needs an toolchain w/ threads, dynamic library
-#
-
-#
 # mosh needs a toolchain w/ C++, threads, dynamic library, wchar, gcc >= 4.8
 #
 # BR2_PACKAGE_MOSQUITTO is not set
 # BR2_PACKAGE_MROUTED is not set
 # BR2_PACKAGE_MRP is not set
+# BR2_PACKAGE_MSTPD is not set
 # BR2_PACKAGE_MTR is not set
 
 #
@@ -3662,7 +3894,7 @@ BR2_PACKAGE_MONGREL2_LIBC_SUPPORTS=y
 # BR2_PACKAGE_NETSTAT_NAT is not set
 
 #
-# NetworkManager needs udev /dev management and a glibc toolchain w/ headers >= 3.2, dynamic library, wchar, threads
+# NetworkManager needs udev /dev management and a glibc toolchain w/ headers >= 4.6, dynamic library, wchar, threads, gcc >= 4.9
 #
 # BR2_PACKAGE_NFACCT is not set
 
@@ -3718,7 +3950,7 @@ BR2_PACKAGE_MONGREL2_LIBC_SUPPORTS=y
 #
 
 #
-# pppd needs a uClibc or glibc toolchain w/ dynamic library
+# pppd needs a toolchain w/ dynamic library
 #
 # BR2_PACKAGE_PPTP_LINUX is not set
 # BR2_PACKAGE_PRIVOXY is not set
@@ -3748,7 +3980,7 @@ BR2_PACKAGE_MONGREL2_LIBC_SUPPORTS=y
 # BR2_PACKAGE_REDIR is not set
 
 #
-# rp-pppoe needs a uClibc or glibc toolchain w/ dynamic library
+# rp-pppoe needs a toolchain w/ dynamic library
 #
 # BR2_PACKAGE_RPCBIND is not set
 # BR2_PACKAGE_RSH_REDONE is not set
@@ -3784,6 +4016,10 @@ BR2_PACKAGE_MONGREL2_LIBC_SUPPORTS=y
 #
 # snort needs a toolchain w/ wchar, threads, dynamic library
 #
+
+#
+# snort3 needs a toolchain w/ C++, wchar, threads, dynamic library, gcc >= 4.9
+#
 # BR2_PACKAGE_SOCAT is not set
 # BR2_PACKAGE_SOCKETCAND is not set
 
@@ -3793,12 +4029,12 @@ BR2_PACKAGE_MONGREL2_LIBC_SUPPORTS=y
 # BR2_PACKAGE_SPAWN_FCGI is not set
 
 #
-# spice server needs a toolchain w/ wchar, threads
+# spice server needs a toolchain w/ wchar, threads, C++
 #
 # BR2_PACKAGE_SPICE_PROTOCOL is not set
 
 #
-# squid needs a toolchain w/ C++, gcc >= 4.8 not affected by bug 64735
+# squid needs a toolchain w/ C++, threads, gcc >= 4.8 not affected by bug 64735
 #
 # BR2_PACKAGE_SSDP_RESPONDER is not set
 # BR2_PACKAGE_SSHGUARD is not set
@@ -3848,6 +4084,10 @@ BR2_PACKAGE_MONGREL2_LIBC_SUPPORTS=y
 #
 # unbound needs a toolchain w/ dynamic library
 #
+
+#
+# uqmi needs a toolchain w/ dynamic library
+#
 # BR2_PACKAGE_UREDIR is not set
 
 #
@@ -3863,7 +4103,7 @@ BR2_PACKAGE_MONGREL2_LIBC_SUPPORTS=y
 #
 
 #
-# vdr needs a glibc toolchain w/ C++, dynamic library, NPTL, wchar, headers >= 3.9
+# vdr needs a toolchain w/ C++, dynamic library, NPTL, wchar, headers >= 3.9
 #
 
 #
@@ -3875,13 +4115,20 @@ BR2_PACKAGE_MONGREL2_LIBC_SUPPORTS=y
 #
 # BR2_PACKAGE_VSFTPD is not set
 # BR2_PACKAGE_VTUN is not set
-# BR2_PACKAGE_WAVEMON is not set
+
+#
+# wavemon needs a toolchain w/ threads, dynamic library
+#
+
+#
+# wireguard-linux-compat needs a Linux kernel to be built
+#
 # BR2_PACKAGE_WIREGUARD_TOOLS is not set
 # BR2_PACKAGE_WIRELESS_REGDB is not set
 # BR2_PACKAGE_WIRELESS_TOOLS is not set
 
 #
-# wireshark needs a toolchain w/ wchar, threads, dynamic library
+# wireshark needs a toolchain w/ wchar, threads, dynamic library, C++
 #
 # BR2_PACKAGE_WPA_SUPPLICANT is not set
 # BR2_PACKAGE_WPAN_TOOLS is not set
@@ -3894,6 +4141,10 @@ BR2_PACKAGE_MONGREL2_LIBC_SUPPORTS=y
 
 #
 # xtables-addons needs a toolchain w/ dynamic library, threads
+#
+
+#
+# zabbix need glibc
 #
 
 #
@@ -3953,6 +4204,10 @@ BR2_PACKAGE_MONGREL2_LIBC_SUPPORTS=y
 #
 
 #
+# opkg-utils needs a toolchain w/ wchar, threads, dynamic library
+#
+
+#
 # Real-Time
 #
 BR2_PACKAGE_XENOMAI_COBALT_ARCH_SUPPORTS=y
@@ -3967,13 +4222,16 @@ BR2_PACKAGE_XENOMAI_COBALT_ARCH_SUPPORTS=y
 #
 
 #
-# checkpolicy needs a toolchain w/ threads, dynamic library
+# checkpolicy needs a toolchain w/ threads, dynamic library, gcc >= 5
 #
 
 #
 # ima-evm-utils needs dynamic library support
 #
-# BR2_PACKAGE_OPTEE_BENCHMARK is not set
+
+#
+# optee-benchmark needs a toolchain w/ threads, dynamic library, headers >= 4.3
+#
 # BR2_PACKAGE_OPTEE_CLIENT is not set
 
 #
@@ -3981,12 +4239,12 @@ BR2_PACKAGE_XENOMAI_COBALT_ARCH_SUPPORTS=y
 #
 
 #
-# policycoreutils needs a toolchain w/ threads, dynamic library
+# policycoreutils needs a toolchain w/ threads, dynamic library, gcc >= 5
 #
 # BR2_PACKAGE_REFPOLICY is not set
 
 #
-# restorecond needs a toolchain w/ wchar, threads, dynamic library
+# restorecond needs a toolchain w/ wchar, threads, dynamic library, gcc >= 5
 #
 
 #
@@ -3995,7 +4253,7 @@ BR2_PACKAGE_XENOMAI_COBALT_ARCH_SUPPORTS=y
 # BR2_PACKAGE_SEMODULE_UTILS is not set
 
 #
-# setools needs a toolchain w/ threads, wchar, dynamic library
+# setools needs a toolchain w/ threads, wchar, dynamic library, gcc >= 5
 #
 
 #
@@ -4016,6 +4274,7 @@ BR2_PACKAGE_XENOMAI_COBALT_ARCH_SUPPORTS=y
 #
 # Utilities
 #
+# BR2_PACKAGE_APG is not set
 # BR2_PACKAGE_AT is not set
 # BR2_PACKAGE_CCRYPT is not set
 # BR2_PACKAGE_DIALOG is not set
@@ -4086,6 +4345,10 @@ BR2_PACKAGE_AUDIT_ARCH_SUPPORTS=y
 #
 # circus needs Python 3 and a toolchain w/ C++, threads
 #
+
+#
+# containerd needs a glibc or musl toolchain w/ threads
+#
 # BR2_PACKAGE_CPULOAD is not set
 # BR2_PACKAGE_DAEMON is not set
 # BR2_PACKAGE_DC3DD is not set
@@ -4096,26 +4359,22 @@ BR2_PACKAGE_AUDIT_ARCH_SUPPORTS=y
 # BR2_PACKAGE_DOCKER_CLI is not set
 
 #
-# docker-compose needs a toolchain w/ C++, wchar, threads, dynamic library
-#
-
-#
-# docker-containerd needs a glibc or musl toolchain w/ threads
-#
-
-#
 # docker-engine needs a glibc or musl toolchain w/ threads
 #
 # BR2_PACKAGE_DOCKER_PROXY is not set
 # BR2_PACKAGE_EARLYOOM is not set
 
 #
-# efibootmgr needs a glibc or uClibc toolchain w/ dynamic library, headers >= 3.12, gcc >= 4.9
+# efibootmgr needs a toolchain w/ dynamic library, headers >= 3.12, gcc >= 4.9
 #
 BR2_PACKAGE_EFIVAR_ARCH_SUPPORTS=y
 
 #
 # efivar needs a toolchain w/ dynamic library, headers >= 3.12, gcc >= 4.9
+#
+
+#
+# embiggen-disk needs a glibc or musl toolchain w/ threads
 #
 
 #
@@ -4137,7 +4396,7 @@ BR2_PACKAGE_EFIVAR_ARCH_SUPPORTS=y
 #
 
 #
-# iotop depends on python or python3
+# iotop depends on python3
 #
 # BR2_PACKAGE_IPRUTILS is not set
 
@@ -4164,6 +4423,11 @@ BR2_PACKAGE_EFIVAR_ARCH_SUPPORTS=y
 #
 # libostree needs a uClibc or glibc toolchain w/ threads, dynamic library, wchar
 #
+BR2_PACKAGE_LIBVIRT_ARCH_SUPPORTS=y
+
+#
+# libvirt needs udev /dev management, a toolchain w/ threads, dynamic library, wchar, kernel headers >= 3.12 (4.11 for AArch64)
+#
 
 #
 # lxc needs a glibc or musl toolchain w/ threads, headers >= 3.0, dynamic library, gcc >= 4.7
@@ -4175,6 +4439,10 @@ BR2_PACKAGE_MAKEDUMPFILE_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_MENDER is not set
 # BR2_PACKAGE_MFOC is not set
+
+#
+# moby-buildkit needs a glibc or musl toolchain w/ threads
+#
 # BR2_PACKAGE_MONIT is not set
 
 #
@@ -4200,7 +4468,7 @@ BR2_PACKAGE_MAKEDUMPFILE_ARCH_SUPPORTS=y
 #
 
 #
-# polkit needs a glibc or musl toolchain with C++, wchar, dynamic library, NPTL, gcc >= 4.9
+# polkit needs a toolchain with dynamic library, wchar, threads, gcc >= 7
 #
 # BR2_PACKAGE_PROCRANK_LINUX is not set
 # BR2_PACKAGE_PWGEN is not set
@@ -4213,6 +4481,10 @@ BR2_PACKAGE_MAKEDUMPFILE_ARCH_SUPPORTS=y
 #
 # rauc needs a toolchain w/ wchar, threads
 #
+
+#
+# runc needs a glibc or musl toolchain w/ threads
+#
 # BR2_PACKAGE_S6 is not set
 # BR2_PACKAGE_S6_LINUX_INIT is not set
 # BR2_PACKAGE_S6_LINUX_UTILS is not set
@@ -4222,8 +4494,13 @@ BR2_PACKAGE_MAKEDUMPFILE_ARCH_SUPPORTS=y
 # BR2_PACKAGE_SCRYPT is not set
 
 #
+# sdbus-c++ needs systemd and a toolchain w/ C++, gcc >= 7
+#
+
+#
 # sdbusplus needs systemd and a toolchain w/ C++, gcc >= 7
 #
+# BR2_PACKAGE_SEATD is not set
 
 #
 # smack needs a toolchain w/ dynamic library, threads, headers >= 3.0
@@ -4232,12 +4509,19 @@ BR2_PACKAGE_MAKEDUMPFILE_ARCH_SUPPORTS=y
 #
 # supervisor needs a python interpreter
 #
-# BR2_PACKAGE_SWUPDATE is not set
+
+#
+# swupdate needs a toolchain w/ dynamic library, threads
+#
 BR2_PACKAGE_SYSTEMD_ARCH_SUPPORTS=y
 BR2_PACKAGE_SYSTEMD_BOOTCHART_ARCH_SUPPORTS=y
 
 #
-# thermald needs a toolchain w/ C++, wchar, threads
+# thermald needs a toolchain w/ C++, wchar, threads, gcc >= 4.9
+#
+
+#
+# thermald needs udev /dev management
 #
 
 #
@@ -4249,7 +4533,7 @@ BR2_PACKAGE_SYSTEMD_BOOTCHART_ARCH_SUPPORTS=y
 #
 
 #
-# tpm2-tools needs a toolchain w/ dynamic library
+# tpm2-tools needs a glibc or musl toolchain w/ dynamic library, wchar
 #
 
 #
@@ -4261,6 +4545,7 @@ BR2_PACKAGE_SYSTEMD_BOOTCHART_ARCH_SUPPORTS=y
 #
 # BR2_PACKAGE_UTIL_LINUX is not set
 # BR2_PACKAGE_WATCHDOG is not set
+# BR2_PACKAGE_WATCHDOGD is not set
 
 #
 # xdg-dbus-proxy needs a toolchain w/ wchar, threads
@@ -4302,9 +4587,10 @@ BR2_PACKAGE_XVISOR_ARCH_SUPPORTS=y
 #
 
 #
-# iso image needs a Linux kernel and either grub2 i386-pc or isolinux to be built
+# iso image needs a Linux kernel and either grub2 or isolinux to be built
 #
 # BR2_TARGET_ROOTFS_JFFS2 is not set
+# BR2_TARGET_ROOTFS_OCI is not set
 # BR2_TARGET_ROOTFS_ROMFS is not set
 # BR2_TARGET_ROOTFS_SQUASHFS is not set
 BR2_TARGET_ROOTFS_TAR=y
@@ -4324,12 +4610,15 @@ BR2_TARGET_ROOTFS_TAR_OPTIONS=""
 # Bootloaders
 #
 # BR2_TARGET_BAREBOX is not set
+BR2_TARGET_EDK2_ARCH_SUPPORTS=y
+# BR2_TARGET_EDK2 is not set
 BR2_TARGET_GRUB2_ARCH_SUPPORTS=y
 
 #
 # grub2 needs a toolchain w/ wchar
 #
 # BR2_TARGET_GUMMIBOOT is not set
+BR2_PACKAGE_SHIM_ARCH_SUPPORTS=y
 # BR2_TARGET_SHIM is not set
 # BR2_TARGET_SYSLINUX is not set
 # BR2_TARGET_UBOOT is not set
@@ -4342,6 +4631,7 @@ BR2_TARGET_GRUB2_ARCH_SUPPORTS=y
 # BR2_PACKAGE_HOST_ANDROID_TOOLS is not set
 # BR2_PACKAGE_HOST_ASN1C is not set
 # BR2_PACKAGE_HOST_BABELTRACE2 is not set
+# BR2_PACKAGE_HOST_BMAP_TOOLS is not set
 # BR2_PACKAGE_HOST_BTRFS_PROGS is not set
 # BR2_PACKAGE_HOST_CHECKPOLICY is not set
 # BR2_PACKAGE_HOST_CHECKSEC is not set
@@ -4349,6 +4639,7 @@ BR2_TARGET_GRUB2_ARCH_SUPPORTS=y
 # BR2_PACKAGE_HOST_CRAMFS is not set
 # BR2_PACKAGE_HOST_CRYPTSETUP is not set
 # BR2_PACKAGE_HOST_DBUS_PYTHON is not set
+# BR2_PACKAGE_HOST_DELVE is not set
 # BR2_PACKAGE_HOST_DFU_UTIL is not set
 # BR2_PACKAGE_HOST_DOS2UNIX is not set
 # BR2_PACKAGE_HOST_DOSFSTOOLS is not set
@@ -4362,6 +4653,7 @@ BR2_TARGET_GRUB2_ARCH_SUPPORTS=y
 # BR2_PACKAGE_HOST_F2FS_TOOLS is not set
 # BR2_PACKAGE_HOST_FAKETIME is not set
 # BR2_PACKAGE_HOST_FATCAT is not set
+# BR2_PACKAGE_HOST_FIRMWARE_UTILS is not set
 # BR2_PACKAGE_HOST_FWUP is not set
 # BR2_PACKAGE_HOST_GENEXT2FS is not set
 # BR2_PACKAGE_HOST_GENIMAGE is not set
@@ -4387,16 +4679,18 @@ BR2_PACKAGE_HOST_GOOGLE_BREAKPAD_ARCH_SUPPORTS=y
 # BR2_PACKAGE_HOST_MKPASSWD is not set
 # BR2_PACKAGE_HOST_MTD is not set
 # BR2_PACKAGE_HOST_MTOOLS is not set
+# BR2_PACKAGE_HOST_NODEJS is not set
 # BR2_PACKAGE_HOST_ODB is not set
 # BR2_PACKAGE_HOST_OPENOCD is not set
 # BR2_PACKAGE_HOST_OPKG_UTILS is not set
+# BR2_PACKAGE_HOST_PAHOLE is not set
 # BR2_PACKAGE_HOST_PARTED is not set
 BR2_PACKAGE_HOST_PATCHELF=y
 # BR2_PACKAGE_HOST_PIGZ is not set
 # BR2_PACKAGE_HOST_PKGCONF is not set
 # BR2_PACKAGE_HOST_PWGEN is not set
-# BR2_PACKAGE_HOST_PYTHON is not set
 # BR2_PACKAGE_HOST_PYTHON_CYTHON is not set
+# BR2_PACKAGE_HOST_PYTHON_GREENLET is not set
 # BR2_PACKAGE_HOST_PYTHON_LXML is not set
 # BR2_PACKAGE_HOST_PYTHON_SIX is not set
 # BR2_PACKAGE_HOST_PYTHON_XLRD is not set
@@ -4407,6 +4701,7 @@ BR2_PACKAGE_HOST_QEMU_USER_ARCH_SUPPORTS=y
 # BR2_PACKAGE_HOST_QEMU is not set
 # BR2_PACKAGE_HOST_QORIQ_RCW is not set
 # BR2_PACKAGE_HOST_RAUC is not set
+# BR2_PACKAGE_HOST_RISCV_ISA_SIM is not set
 BR2_PACKAGE_HOST_RUSTC_ARCH_SUPPORTS=y
 BR2_PACKAGE_HOST_RUSTC_ARCH="x86_64"
 # BR2_PACKAGE_HOST_RUSTC is not set
@@ -4414,6 +4709,7 @@ BR2_PACKAGE_PROVIDES_HOST_RUSTC="host-rust-bin"
 # BR2_PACKAGE_HOST_SAM_BA is not set
 # BR2_PACKAGE_HOST_SDBUSPLUS is not set
 # BR2_PACKAGE_HOST_SENTRY_CLI is not set
+# BR2_PACKAGE_HOST_SLOCI_IMAGE is not set
 # BR2_PACKAGE_HOST_SQUASHFS is not set
 # BR2_PACKAGE_HOST_SWIG is not set
 # BR2_PACKAGE_HOST_UBOOT_TOOLS is not set
@@ -4429,12 +4725,113 @@ BR2_PACKAGE_PROVIDES_HOST_RUSTC="host-rust-bin"
 #
 
 #
-# Legacy options removed in 2021.02
+# Legacy options removed in 2022.02
 #
+# BR2_sh2a is not set
+BR2_TARGET_ROOTFS_OCI_ENTRYPOINT_ARGS=""
+# BR2_PACKAGE_LIBCURL_LIBNSS is not set
+# BR2_PACKAGE_WESTON_DEFAULT_FBDEV is not set
+# BR2_PACKAGE_WESTON_FBDEV is not set
+# BR2_PACKAGE_PYTHON_PYCLI is not set
+# BR2_PACKAGE_LINUX_TOOLS_BPFTOOL is not set
+# BR2_TARGET_UBOOT_NEEDS_PYTHON2 is not set
+# BR2_PACKAGE_PYTHON_FUNCTOOLS32 is not set
+# BR2_PACKAGE_PYTHON_ENUM34 is not set
+# BR2_PACKAGE_PYTHON_ENUM is not set
+# BR2_PACKAGE_PYTHON_DIALOG is not set
+# BR2_PACKAGE_PYTHON_CONFIGOBJ is not set
+# BR2_PACKAGE_PYTHON_YIELDFROM is not set
+# BR2_PACKAGE_PYTHON_TYPING is not set
+# BR2_PACKAGE_PYTHON_SUBPROCESS32 is not set
+# BR2_PACKAGE_PYTHON_SINGLEDISPATCH is not set
+# BR2_PACKAGE_PYTHON_PYRO is not set
+# BR2_PACKAGE_PYTHON_PYPCAP is not set
+# BR2_PACKAGE_PYTHON_PATHLIB2 is not set
+# BR2_PACKAGE_PYTHON_PAM is not set
+# BR2_PACKAGE_PYTHON_NFC is not set
+# BR2_PACKAGE_PYTHON_MAD is not set
+# BR2_PACKAGE_PYTHON_IPADDRESS is not set
+# BR2_PACKAGE_PYTHON_IPADDR is not set
+# BR2_PACKAGE_PYTHON_ID3 is not set
+# BR2_PACKAGE_PYTHON_FUTURES is not set
+# BR2_PACKAGE_PYTHON_BACKPORTS_SSL_MATCH_HOSTNAME is not set
+# BR2_PACKAGE_PYTHON_BACKPORTS_SHUTIL_GET_TERMINAL_SIZE is not set
+# BR2_PACKAGE_PYTHON_BACKPORTS_ABC is not set
+# BR2_PACKAGE_PYTHON is not set
+# BR2_TARGET_UBOOT_ZYNQ_IMAGE is not set
+# BR2_PACKAGE_HOST_GDB_PYTHON is not set
+# BR2_PACKAGE_GSTREAMER1_MM is not set
+# BR2_KERNEL_HEADERS_5_14 is not set
+# BR2_PACKAGE_PYTHON_BACKPORTS_FUNCTOOLS_LRU_CACHE is not set
+# BR2_PACKAGE_CIVETWEB_WITH_LUA is not set
+# BR2_PACKAGE_SUNXI_MALI_MAINLINE_DRIVER is not set
+# BR2_PACKAGE_SUNXI_MALI_MAINLINE is not set
+# BR2_PACKAGE_SUNXI_MALI_MAINLINE_R6P2 is not set
+# BR2_PACKAGE_SUNXI_MALI_MAINLINE_R8P1 is not set
+# BR2_PACKAGE_QT5WEBKIT_EXAMPLES is not set
+# BR2_TOOLCHAIN_EXTERNAL_BOOTLIN_RISCV64_GLIBC_BLEEDING_EDGE is not set
+# BR2_TOOLCHAIN_EXTERNAL_BOOTLIN_RISCV64_MUSL_BLEEDING_EDGE is not set
+# BR2_PACKAGE_IPUTILS_TFTPD is not set
+# BR2_PACKAGE_IPUTILS_TRACEROUTE6 is not set
+# BR2_PACKAGE_LIBMEDIAART_BACKEND_NONE is not set
+# BR2_PACKAGE_MPD_UPNP is not set
+
+#
+# Legacy options removed in 2021.11
+#
+# BR2_OPENJDK_VERSION_LTS is not set
+# BR2_OPENJDK_VERSION_LATEST is not set
+# BR2_PACKAGE_MPD_TIDAL is not set
+# BR2_PACKAGE_MROUTED_RSRR is not set
+# BR2_BINUTILS_VERSION_CSKY is not set
+# BR2_GCC_VERSION_CSKY is not set
+# BR2_PACKAGE_CANFESTIVAL is not set
+# BR2_PACKAGE_NMAP_NDIFF is not set
+# BR2_GDB_VERSION_8_3 is not set
+# BR2_PACKAGE_PYTHON_MELD3 is not set
+# BR2_PACKAGE_STRONGSWAN_EAP is not set
+# BR2_PACKAGE_GNURADIO_PAGER is not set
+# BR2_KERNEL_HEADERS_5_11 is not set
+# BR2_KERNEL_HEADERS_5_12 is not set
+# BR2_KERNEL_HEADERS_5_13 is not set
+
+#
+# Legacy options removed in 2021.08
+#
+BR2_TARGET_GRUB2_BUILTIN_MODULES=""
+BR2_TARGET_GRUB2_BUILTIN_CONFIG=""
+# BR2_PACKAGE_LIBMCRYPT is not set
+# BR2_PACKAGE_MCRYPT is not set
+# BR2_PACKAGE_PHP_EXT_MCRYPT is not set
+# BR2_BINUTILS_VERSION_2_34_X is not set
+# BR2_PACKAGE_LIBSOIL is not set
+# BR2_PACKAGE_CLAPACK is not set
+# BR2_PACKAGE_SPIDERMONKEY is not set
+# BR2_PACKAGE_KODI_LIBVA is not set
+# BR2_PACKAGE_PYTHON_COHERENCE is not set
+# BR2_PACKAGE_PHP_EXT_XMLRPC is not set
+# BR2_GCC_VERSION_8_X is not set
+
+#
+# Legacy options removed in 2021.05
+#
+# BR2_PACKAGE_UDISKS_LVM2 is not set
+# BR2_PACKAGE_LVM2_APP_LIBRARY is not set
+# BR2_PACKAGE_LVM2_LVMETAD is not set
+# BR2_PACKAGE_MONKEY is not set
+# BR2_PACKAGE_DOCKER_CONTAINERD is not set
+# BR2_PACKAGE_IOSTAT is not set
 # BR2_PACKAGE_SCONESERVER_HTTP_SCONESITE_IMAGE is not set
 # BR2_PACKAGE_XSERVER_XORG_SERVER_KDRIVE_EVDEV is not set
 # BR2_PACKAGE_XSERVER_XORG_SERVER_KDRIVE_KBD is not set
 # BR2_PACKAGE_XSERVER_XORG_SERVER_KDRIVE_MOUSE is not set
+# BR2_PACKAGE_MESA3D_OSMESA_CLASSIC is not set
+# BR2_PACKAGE_MESA3D_DRI_DRIVER_SWRAST is not set
+# BR2_PACKAGE_KODI_SCREENSAVER_CRYSTALMORPH is not set
+
+#
+# Legacy options removed in 2021.02
+#
 # BR2_PACKAGE_MPD_AUDIOFILE is not set
 # BR2_PACKAGE_AUDIOFILE is not set
 # BR2_BINUTILS_VERSION_2_33_X is not set
@@ -4452,6 +4849,9 @@ BR2_PACKAGE_PROVIDES_HOST_RUSTC="host-rust-bin"
 #
 # Legacy options removed in 2020.11
 #
+# BR2_PACKAGE_GPSD_FIXED_PORT_SPEED is not set
+# BR2_PACKAGE_GPSD_RECONFIGURE is not set
+# BR2_PACKAGE_GPSD_CONTROLSEND is not set
 # BR2_PACKAGE_OPENCV is not set
 # BR2_PACKAGE_LIBCROCO is not set
 # BR2_PACKAGE_BELLAGIO is not set


### PR DESCRIPTION
Proper upgrade to 2022.02.3 config. All new default options have been set, deprecated options included, and binutils is now 2.37.